### PR TITLE
Add JSON and Pretty ANSI Formatter

### DIFF
--- a/src/logging/LogLevel.hx
+++ b/src/logging/LogLevel.hx
@@ -1,9 +1,9 @@
 package logging;
 
-enum LogLevel {
-    Info;
-    Debug;
-    Error;
-    Warning;
-    Data;
+enum abstract LogLevel(String) {
+    var Info;
+    var Debug;
+    var Error;
+    var Warning;
+    var Data;
 }

--- a/src/logging/formatters/JSONFormatter.hx
+++ b/src/logging/formatters/JSONFormatter.hx
@@ -1,30 +1,11 @@
 package logging.formatters;
 
-using StringTools;
-
-class DefaultFormatter implements ILogLineFormatter {
+class JSONFormatter implements ILogLineFormatter {
     public function new() {
     }
 
     public function format(data:LogData, buffer:StringBuf) {
-        buffer.add(data.timestamp);
-        buffer.add(" > ");
-        buffer.add(cast(data.level, String).toUpperCase().rpad(" ", 7));
-        buffer.add(" > ");
-
-        if (data.ref != null) {
-            buffer.add(data.ref);
-            buffer.add(" > ");
-        }
-
-        if (data.instanceId != null) {
-            buffer.add(data.instanceId);
-            buffer.add(" > ");
-        }
-
-        if (data.message != null) {
-            buffer.add(data.message);
-        }
+        buffer.add(haxe.Json.stringify(data));
     }
 
     public function formatObject(obj:Any):String {

--- a/src/logging/formatters/PrettyANSIFormatter.hx
+++ b/src/logging/formatters/PrettyANSIFormatter.hx
@@ -1,0 +1,68 @@
+package logging.formatters;
+
+using StringTools;
+
+typedef Colors = {
+	level: String,
+	className: String,
+	reset: String
+}
+
+class PrettyANSIFormatter implements ILogLineFormatter {
+    var colors: Colors;
+
+	public function new() {
+		colors = {
+			level: "",
+			className: "\033[33m",
+			reset: "\033[0m"
+		};
+	}
+
+    public function format(data:LogData, buffer:StringBuf) {
+		colors.level = switch (data.level) {
+			case Info: "\033[34m";
+			case Debug: "\033[32m";
+			case Error: "\033[31m";
+			case Warning: "\033[33m";
+			case Data: "\033[35m";
+		}
+
+		buffer.add(colors.level);
+        buffer.add(cast(data.level, String).toUpperCase());
+        buffer.add(colors.reset + " ");
+
+        if (data.ref != null) {
+			buffer.add(colors.className + "[");
+            buffer.add(data.ref);
+            buffer.add("] " + colors.reset);
+        }
+		
+		if (data.message != null) {
+			buffer.add(data.message + " ");
+        }
+
+		#if !js
+		if (data.data != null) {
+			buffer.add("".lpad(" ", 4) + formatObject(data.data));
+		}
+		#end
+    }
+
+    public function formatObject(obj:Any):String {
+        if (obj == null) {
+            return "";
+        }
+        switch (Type.typeof(obj)) {
+            case TClass(haxe.ds.StringMap):
+                var o:Dynamic = {};
+                var sm = cast(obj, haxe.ds.StringMap<Dynamic>);
+                for (key in sm.keys()) {
+                    Reflect.setField(o, key, sm.get(key));
+                }
+                return haxe.Json.stringify(o);
+            case _:
+        }
+        return Std.string(obj);
+    }
+}


### PR DESCRIPTION
Adding two new formatters to the library
The JSON Formatter was just a quick personal experiment that seemed like it would be useful for people. Some logging libraries such as Zap for Go uses this primarily. I am sure they do some more fancy things than what I am doing, but better than nothing.
The Pretty ANSI one is one that I am planning to use for my projects. It is meant to be less verbose than the default one. This is good for less-formal projects.
Both of these should be expanded upon later, but I don't want to be focusing on it.
I modified LogLevel to use an abstract enum, this is because the JSON encoder does not handle normal enums well. I am unsure on the purpose of formatObject, is it just for cross-platform reasons?